### PR TITLE
exec wayvnc

### DIFF
--- a/snap/local/ubuntu-frame-vnc
+++ b/snap/local/ubuntu-frame-vnc
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-${SNAP}/usr/local/bin/wayvnc --gpu localhost 5900
+exec ${SNAP}/usr/local/bin/wayvnc --gpu localhost 5900


### PR DESCRIPTION
We don't need the sh process to wait for wayvnc to exit.

Also this makes ubuntu-frame-vnc work with Miriway (which tracks the pid from the process it launches)